### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Summary, on the remote node:
 
     `sudo service sshd restart`
 
+##### Note:
+
+As of Rundeck 3.3, RD_* remote environment variables will no longer be sent by default when using JSCH node executor. You can turn them back on with a configuration change. To enable it for all nodes in all projects, add `framework.ssh-send-env=true` to your `framework.properties` file. [For more options and information, see here](https://docs.rundeck.com/docs/upgrading/upgrading-to-rundeck-3.3.html#jsch-node-executor-timeouts-and-environment-variables).
+
 #### Rundeck setup
 
 Create an item in Rundeck's [Key Storage](<https://www.rundeck.com/blog/use-rundecks-key-storage-to-manage-passwords-and-secrets>) that houses your keystore password (and private key password, if applicable).


### PR DESCRIPTION
Adds note about re-enabling the passing of RD_ envars as of Rundeck 3.3